### PR TITLE
G923 support fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,7 +47,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
 
         self.thread = None
         self.running = False
-        last_send = 0.0
+        self.last_send = 0.0
 
         self.set_title("G29 RPM LED indicator")
         self.set_default_size(250, 100)
@@ -137,7 +137,7 @@ class WheelRPMWindow(Gtk.ApplicationWindow):
                 wheel.leds_rpm(percent)
               else:
                 wheel.leds_rpm(0)
-              last_send = now
+              self.last_send = now
 
     def _on_factory_widget_setup(self, factory, list_item):
         box = Gtk.Box(spacing=6, orientation=Gtk.Orientation.HORIZONTAL)

--- a/wheels/detect.py
+++ b/wheels/detect.py
@@ -1,11 +1,12 @@
 import hid
-from wheels.g29  import G29
-from wheels.g923 import G923
+from wheels.wheels import G29
+from wheels.wheels import G923xbox
+from wheels.wheels import G923ps4
 from wheels.base import BaseWheel
 
 # Register every VID/PID with its class
 DEVICE_MAP: dict[tuple[int, int], type[BaseWheel]] = {}
-for cls in (G29, G923):
+for cls in (G29, G923xbox, G923ps4):
     for pid in cls.PRODUCT_IDS:
         DEVICE_MAP[(cls.VENDOR_ID, pid)] = cls
 

--- a/wheels/g29.py
+++ b/wheels/g29.py
@@ -1,9 +1,0 @@
-from wheels.base import BaseWheel
-
-
-class G29(BaseWheel):
-    PRODUCT_IDS = (0xC24F, 0xC260)   # PS3 / PS4 variants
-
-    def _led_report(self, bits: int):
-        # G29 format: [0xF8, 0x12, bits, 0, 0, 0, 1]
-        return (0xF8, 0x12, bits, 0x00, 0x00, 0x00, 0x01)

--- a/wheels/protocols.py
+++ b/wheels/protocols.py
@@ -1,9 +1,11 @@
 from wheels.base import BaseWheel
 
+class HIDClassic(BaseWheel):
+    def _led_report(self, bits: int):
+        # Classic hid format: [0xF8, 0x12, bits, 0, 0, 0, 1]
+        return (0xF8, 0x12, bits, 0x00, 0x00, 0x00, 0x01)
 
-class G923(BaseWheel):
-    PRODUCT_IDS = (0xC26E, 0xC267)   # Xbox / PS4 variants
-
+class HIDpp(BaseWheel):
     def _post_connect_setup(self):
         # put wheel into “direct LED” mode once
         self._dev.write(bytes((0x11, 0xFF, 0x12, 0x31, 0x00)))

--- a/wheels/wheels.py
+++ b/wheels/wheels.py
@@ -1,0 +1,11 @@
+from wheels.protocols import HIDClassic
+from wheels.protocols import HIDpp
+
+class G29(HIDClassic):
+    PRODUCT_IDS = (0xC24F, 0xC260)   # PS3 / PS4 variants
+
+class G923xbox(HIDpp):
+    PRODUCT_IDS = [0xC26E]   # Xbox variant
+
+class G923ps4(HIDClassic):
+    PRODUCT_IDS = [0xC267]   # PS4 variant


### PR DESCRIPTION
Fixed `AttributeError: 'WheelRPMWindow' object has no attribute 'last_send'` error.

Also separated the protocol specific messages in protocol classes, and separated G923 models, as they use different protocols.